### PR TITLE
fix: Correct reference to Docker container

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,7 @@ def seam_backend():
     with PostgresContainer("postgres:13", dbname="postgres") as pg:
         db_host = "host.docker.internal" if sys.platform == "darwin" else "172.17.0.1"
         db_url = f"postgresql://test:test@{db_host}:{pg.get_exposed_port(pg.port_to_expose)}/postgres"
-        with DockerContainer("helloseam/seam-connect").with_env(
+        with DockerContainer("seamapi/seam-connect").with_env(
             "DATABASE_URL",
             db_url,
         ).with_env("POSTGRES_DATABASE", "postgres").with_env(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,7 @@ def seam_backend():
     with PostgresContainer("postgres:13", dbname="postgres") as pg:
         db_host = "host.docker.internal" if sys.platform == "darwin" else "172.17.0.1"
         db_url = f"postgresql://test:test@{db_host}:{pg.get_exposed_port(pg.port_to_expose)}/postgres"
-        with DockerContainer("seamapi/seam-connect").with_env(
+        with DockerContainer("ghcr.io/seamapi/seam-connect").with_env(
             "DATABASE_URL",
             db_url,
         ).with_env("POSTGRES_DATABASE", "postgres").with_env(


### PR DESCRIPTION
Earlier the change was to `helloseam/seam-connect` but it was discovered it was supposed to be `seamapi/seam-connect`.