### PR TITLE
Centralize request-making logic

### DIFF
--- a/seamapi/access_codes.py
+++ b/seamapi/access_codes.py
@@ -67,13 +67,13 @@ class AccessCodes(AbstractAccessCodes):
         """
 
         device_id = to_device_id(device)
-        res = requests.get(
-            f"{self.seam.api_url}/access_codes/list?device_id={device_id}",
-            headers={"Authorization": f"Bearer {self.seam.api_key}"},
+        res = self.seam.make_request(
+            "GET",
+            "/access_codes/list",
+            params={"device_id": device_id},
         )
-        if not res.ok:
-            raise Exception(res.text)
-        access_codes = res.json()["access_codes"]
+        access_codes = res["access_codes"]
+
         return [AccessCode.from_dict(ac) for ac in access_codes]
 
     def get(
@@ -105,14 +105,14 @@ class AccessCodes(AbstractAccessCodes):
             params["access_code_id"] = to_access_code_id(access_code)
         if device:
             params["device_id"] = to_device_id(device)
-        res = requests.get(
-            f"{self.seam.api_url}/access_codes/get",
-            headers={"Authorization": f"Bearer {self.seam.api_key}"},
+
+        res = self.seam.make_request(
+            "GET",
+            "/access_codes/get",
             params=params,
         )
-        if not res.ok:
-            raise Exception(res.text)
-        return AccessCode.from_dict(res.json()["access_code"])
+
+        return AccessCode.from_dict(res["access_code"])
 
     def create(
         self,
@@ -157,17 +157,18 @@ class AccessCodes(AbstractAccessCodes):
             create_payload["starts_at"] = starts_at
         if ends_at is not None:
             create_payload["ends_at"] = ends_at
-        res = requests.post(
-            f"{self.seam.api_url}/access_codes/create",
-            headers={"Authorization": f"Bearer {self.seam.api_key}"},
+
+        res = self.seam.make_request(
+            "POST",
+            "/access_codes/create",
             json=create_payload,
         )
-        if not res.ok:
-            raise Exception(res.text)
+
         action_attempt = self.seam.action_attempts.poll_until_ready(
-            res.json()["action_attempt"]["action_attempt_id"]
+            res["action_attempt"]["action_attempt_id"]
         )
         success_res: Any = action_attempt.result
+
         return AccessCode.from_dict(success_res["access_code"])
 
     def update(
@@ -218,17 +219,18 @@ class AccessCodes(AbstractAccessCodes):
             update_payload["starts_at"] = starts_at
         if ends_at is not None:
             update_payload["ends_at"] = ends_at
-        res = requests.post(
-            f"{self.seam.api_url}/access_codes/update",
-            headers={"Authorization": f"Bearer {self.seam.api_key}"},
+
+        res = self.seam.make_request(
+            "POST",
+            "/access_codes/update",
             json=update_payload,
         )
-        if not res.ok:
-            raise Exception(res.text)
+
         action_attempt = self.seam.action_attempts.poll_until_ready(
-            res.json()["action_attempt"]["action_attempt_id"]
+            res["action_attempt"]["action_attempt_id"]
         )
         success_res: Any = action_attempt.result
+
         return AccessCode.from_dict(success_res["access_code"])
 
     def delete(
@@ -261,14 +263,15 @@ class AccessCodes(AbstractAccessCodes):
         create_payload = {"access_code_id": access_code_id}
         if device is not None:
             create_payload["device_id"] = to_device_id(device)
-        res = requests.delete(
-            (f"{self.seam.api_url}/access_codes/delete"),
-            headers={"Authorization": f"Bearer {self.seam.api_key}"},
+
+        res = self.seam.make_request(
+            "DELETE",
+            "/access_codes/delete",
             json=create_payload,
         )
-        if not res.ok:
-            raise Exception(res.text)
+
         action_attempt = self.seam.action_attempts.poll_until_ready(
-            res.json()["action_attempt"]["action_attempt_id"]
+            res["action_attempt"]["action_attempt_id"]
         )
+
         return action_attempt

--- a/seamapi/action_attempts.py
+++ b/seamapi/action_attempts.py
@@ -65,20 +65,20 @@ class ActionAttempts(AbstractActionAttempts):
         """
 
         action_attempt_id = to_action_attempt_id(action_attempt)
-        res = requests.get(
-            f"{self.seam.api_url}/action_attempts/get",
-            headers={"Authorization": f"Bearer {self.seam.api_key}"},
+        res = self.seam.make_request(
+            "GET",
+            "/action_attempts/get",
             params={"action_attempt_id": action_attempt_id},
         )
-        if not res.ok:
-            raise Exception(res.text)
-        json_aa = res.json()["action_attempt"]
+
+        json_aa = res["action_attempt"]
         error = None
         if "error" in json_aa and json_aa["error"] is not None:
             error = ActionAttemptError(
                 type=json_aa["error"]["type"],
                 message=json_aa["error"]["message"],
             )
+
         return ActionAttempt(
             action_attempt_id=json_aa["action_attempt_id"],
             status=json_aa["status"],
@@ -107,7 +107,8 @@ class ActionAttempts(AbstractActionAttempts):
 
         updated_action_attempt = None
         while (
-            updated_action_attempt is None or updated_action_attempt.status == "pending"
+            updated_action_attempt is None
+            or updated_action_attempt.status == "pending"
         ):
             updated_action_attempt = self.get(action_attempt)
             time.sleep(0.25)

--- a/seamapi/connect_webviews.py
+++ b/seamapi/connect_webviews.py
@@ -59,16 +59,14 @@ class ConnectWebviews(AbstractConnectWebviews):
             A list of connect webviews
         """
 
-        res = requests.get(
-            f"{self.seam.api_url}/connect_webviews/list",
-            headers={"Authorization": f"Bearer {self.seam.api_key}"},
+        res = self.seam.make_request(
+            "GET",
+            "/connect_webviews/list",
         )
-        if not res.ok:
-            raise Exception(res.text)
-        json_webviews = res.json()["connect_webviews"]
+        json_webviews = res["connect_webviews"]
+
         return [
-            ConnectWebview(**json_webview)
-            for json_webview in json_webviews
+            ConnectWebview(**json_webview) for json_webview in json_webviews
         ]
 
     def get(
@@ -92,14 +90,13 @@ class ConnectWebviews(AbstractConnectWebviews):
         """
 
         connect_webview_id = to_connect_webview_id(connect_webview)
-        res = requests.get(
-            f"{self.seam.api_url}/connect_webviews/get",
-            headers={"Authorization": f"Bearer {self.seam.api_key}"},
+        res = self.seam.make_request(
+            "GET",
+            "/connect_webviews/get",
             params={"connect_webview_id": connect_webview_id},
         )
-        if not res.ok:
-            raise Exception(res.text)
-        json_webview = res.json()["connect_webview"]
+        json_webview = res["connect_webview"]
+
         return ConnectWebview(**json_webview)
 
     def create(
@@ -134,12 +131,12 @@ class ConnectWebviews(AbstractConnectWebviews):
             create_payload["custom_redirect_url"] = custom_redirect_url
         if device_selection_mode is not None:
             create_payload["device_selection_mode"] = device_selection_mode
-        res = requests.post(
-            f"{self.seam.api_url}/connect_webviews/create",
-            headers={"Authorization": f"Bearer {self.seam.api_key}"},
+
+        res = self.seam.make_request(
+            "POST",
+            "/connect_webviews/create",
             json=create_payload,
         )
-        if not res.ok:
-            raise Exception(res.text)
-        json_webview = res.json()["connect_webview"]
+        json_webview = res["connect_webview"]
+
         return ConnectWebview(**json_webview)

--- a/seamapi/connected_accounts.py
+++ b/seamapi/connected_accounts.py
@@ -154,7 +154,7 @@ class ConnectedAccounts(AbstractConnectedAccounts):
         self.seam.make_request(
             "DELETE",
             "/connected_accounts/delete",
-            data={"connected_account_id": connected_account_id},
+            json={"connected_account_id": connected_account_id},
         )
 
         return True

--- a/seamapi/connected_accounts.py
+++ b/seamapi/connected_accounts.py
@@ -56,13 +56,12 @@ class ConnectedAccounts(AbstractConnectedAccounts):
             A list of connected accounts.
         """
 
-        res = requests.get(
-            f"{self.seam.api_url}/connected_accounts/list",
-            headers={"Authorization": f"Bearer {self.seam.api_key}"},
+        res = self.seam.make_request(
+            "GET",
+            "/connected_accounts/list",
         )
-        if not res.ok:
-            raise Exception(res.text)
-        json_accounts: List[Dict[str, Any]] = res.json()["connected_accounts"]
+        json_accounts: List[Dict[str, Any]] = res["connected_accounts"]
+
         return [
             ConnectedAccount(
                 connected_account_id=json_account["connected_account_id"],
@@ -76,7 +75,9 @@ class ConnectedAccounts(AbstractConnectedAccounts):
 
     def get(
         self,
-        connected_account: Union[ConnectedAccountId, ConnectedAccount, None] = None,
+        connected_account: Union[
+            ConnectedAccountId, ConnectedAccount, None
+        ] = None,
         email: Email = None,
     ) -> ConnectedAccount:
         """Gets a connected account.
@@ -102,21 +103,24 @@ class ConnectedAccounts(AbstractConnectedAccounts):
         params = {}
 
         if connected_account:
-            params["connected_account_id"] = to_connected_account_id(connected_account)
+            params["connected_account_id"] = to_connected_account_id(
+                connected_account
+            )
         if email:
             params["email"] = email
 
         if not connected_account and not email:
-            raise Exception("Must provide either ConnectedAccount (ConnectedAccount or ConnectedAccountId) or Email")
-        
-        res = requests.get(
-            f"{self.seam.api_url}/connected_accounts/get",
-            headers={"Authorization": f"Bearer {self.seam.api_key}"},
+            raise Exception(
+                "Must provide either ConnectedAccount (ConnectedAccount or ConnectedAccountId) or Email"
+            )
+
+        res = self.seam.make_request(
+            "GET",
+            "/connected_accounts/get",
             params=params,
         )
-        if not res.ok:
-            raise Exception(res.text)
-        json_account: Dict[str, Any] = res.json()["connected_account"]
+        json_account: Dict[str, Any] = res["connected_account"]
+
         return ConnectedAccount(
             connected_account_id=json_account["connected_account_id"],
             created_at=json_account["created_at"],
@@ -147,12 +151,10 @@ class ConnectedAccounts(AbstractConnectedAccounts):
 
         connected_account_id = to_connected_account_id(connected_account)
 
-        res = requests.delete(
-            f"{self.seam.api_url}/connected_accounts/delete",
-            headers={"Authorization": f"Bearer {self.seam.api_key}"},
+        self.seam.make_request(
+            "DELETE",
+            "/connected_accounts/delete",
             data={"connected_account_id": connected_account_id},
         )
-        if not res.ok:
-            raise Exception(res.text)
 
         return True

--- a/seamapi/devices.py
+++ b/seamapi/devices.py
@@ -85,19 +85,19 @@ class Devices(AbstractDevices):
                 connected_account
             )
         if connect_webview:
-            params[
-                "connect_webview_id"
-            ] =  to_connect_webview_id(connect_webview)
+            params["connect_webview_id"] = to_connect_webview_id(
+                connect_webview
+            )
         if device_type:
             params["device_type"] = device_type
-        res = requests.get(
-            f"{self.seam.api_url}/devices/list",
+
+        res = self.seam.make_request(
+            "GET",
+            "/devices/list",
             params=params,
-            headers={"Authorization": f"Bearer {self.seam.api_key}"},
         )
-        if not res.ok:
-            raise Exception(res.text)
-        devices = res.json()["devices"]
+        devices = res["devices"]
+
         return [Device.from_dict(d) for d in devices]
 
     def get(
@@ -129,11 +129,7 @@ class Devices(AbstractDevices):
             params["device_id"] = to_device_id(device)
         if name:
             params["name"] = name
-        res = self.seam.make_request(
-            "GET",
-            "/devices/get",
-            params=params
-        )
+        res = self.seam.make_request("GET", "/devices/get", params=params)
         json_device = res["device"]
         return Device.from_dict(json_device)
 
@@ -170,20 +166,18 @@ class Devices(AbstractDevices):
         if not device:
             raise Exception("device is required")
 
-        params = {
+        update_payload = {
             "device_id": to_device_id(device),
             "name": name,
             "properties": properties,
             "location": location,
         }
 
-        res = requests.post(
-            f"{self.seam.api_url}/devices/update",
-            headers={"Authorization": f"Bearer {self.seam.api_key}"},
-            params=params,
+        self.seam.make_request(
+            "POST",
+            "/devices/update",
+            json=update_payload,
         )
-        if not res.ok:
-            raise Exception(res.text)
 
         return True
 

--- a/seamapi/devices.py
+++ b/seamapi/devices.py
@@ -129,14 +129,12 @@ class Devices(AbstractDevices):
             params["device_id"] = to_device_id(device)
         if name:
             params["name"] = name
-        res = requests.get(
-            f"{self.seam.api_url}/devices/get",
-            headers={"Authorization": f"Bearer {self.seam.api_key}"},
-            params=params,
+        res = self.seam.make_request(
+            "GET",
+            "/devices/get",
+            params=params
         )
-        if not res.ok:
-            raise Exception(res.text)
-        json_device = res.json()["device"]
+        json_device = res["device"]
         return Device.from_dict(json_device)
 
     def update(
@@ -178,7 +176,7 @@ class Devices(AbstractDevices):
             "properties": properties,
             "location": location,
         }
-        
+
         res = requests.post(
             f"{self.seam.api_url}/devices/update",
             headers={"Authorization": f"Bearer {self.seam.api_key}"},
@@ -188,7 +186,7 @@ class Devices(AbstractDevices):
             raise Exception(res.text)
 
         return True
-    
+
     def delete(self, device: Union[DeviceId, Device]) -> bool:
         """Deletes a device.
 

--- a/seamapi/devices.py
+++ b/seamapi/devices.py
@@ -207,7 +207,7 @@ class Devices(AbstractDevices):
 
         delete_payload = {"device_id": to_device_id(device)}
         self.seam.make_request(
-            "POST",
+            "DELETE",
             "/devices/delete",
             json=delete_payload,
         )

--- a/seamapi/devices.py
+++ b/seamapi/devices.py
@@ -202,13 +202,11 @@ class Devices(AbstractDevices):
         if not device:
             raise Exception("device is required")
 
-        params = {"device_id": to_device_id(device)}
-        res = requests.post(
-            f"{self.seam.api_url}/devices/delete",
-            headers={"Authorization": f"Bearer {self.seam.api_key}"},
-            params=params,
+        delete_payload = {"device_id": to_device_id(device)}
+        self.seam.make_request(
+            "POST",
+            "/devices/delete",
+            json=delete_payload,
         )
-        if not res.ok:
-            raise Exception(res.text)
 
         return None

--- a/seamapi/devices.py
+++ b/seamapi/devices.py
@@ -168,10 +168,13 @@ class Devices(AbstractDevices):
 
         update_payload = {
             "device_id": to_device_id(device),
-            "name": name,
-            "properties": properties,
-            "location": location,
         }
+        if name:
+            update_payload["name"] = name
+        if properties:
+            update_payload["properties"] = properties
+        if location:
+            update_payload["location"] = location
 
         self.seam.make_request(
             "POST",

--- a/seamapi/events.py
+++ b/seamapi/events.py
@@ -41,22 +41,22 @@ class Events(AbstractEvents):
         device_id: Optional[str] = None,
         device_ids: Optional[list] = None,
         event_type: Optional[str] = None,
-        event_types: Optional[list] = None
+        event_types: Optional[list] = None,
     ) -> List[Event]:
         """Gets a list of events.
 
         Parameters
         ----------
-			since : str
-				ISO 8601 timestamp of the earliest event to return
-			device_id : Optional[str]
-				Device ID to filter events by
-			device_ids : Optional[list]
-				Device IDs to filter events by
-			event_type : Optional[str]
-				Event type to filter events by
-			event_types : Optional[list]
-				Event types to filter events by
+        since : str
+            ISO 8601 timestamp of the earliest event to return
+        device_id : Optional[str]
+            Device ID to filter events by
+        device_ids : Optional[list]
+            Device IDs to filter events by
+        event_type : Optional[str]
+            Event type to filter events by
+        event_types : Optional[list]
+            Event types to filter events by
 
         Raises
         ------
@@ -78,29 +78,26 @@ class Events(AbstractEvents):
             "device_id": device_id,
             "device_ids": device_ids,
             "event_type": event_type,
-            "event_types": event_types
+            "event_types": event_types,
         }
 
         for name in arguments:
             if arguments[name]:
                 params.update({name: arguments[name]})
 
-        res = requests.get(
-            f"{self.seam.api_url}/events/list",
+        res = self.seam.make_request(
+            "GET",
+            "/events/list",
             params=params,
-            headers={"Authorization": f"Bearer {self.seam.api_key}"},
         )
-        if not res.ok:
-            raise Exception(res.text)
 
-        events = res.json()["events"]
-        return events
+        return res["events"]
 
     def get(
         self,
         event_id: Optional[str] = None,
         event_type: Optional[str] = None,
-        device_id: Optional[str] = None
+        device_id: Optional[str] = None,
     ) -> Event:
         """Get an Event.
 
@@ -127,23 +124,20 @@ class Events(AbstractEvents):
         arguments = {
             "event_id": event_id,
             "event_type": event_type,
-            "device_id": device_id
+            "device_id": device_id,
         }
 
         for name in arguments:
             if arguments[name]:
-                params.update({ name: arguments[name] })
+                params.update({name: arguments[name]})
 
-        res = requests.get(
-            f"{self.seam.api_url}/events/get",
-            headers={"Authorization": f"Bearer {self.seam.api_key}"},
+        res = self.seam.make_request(
+            "GET",
+            "/events/get",
             params=params,
         )
-        
-        if not res.ok:
-            raise Exception(res.text)
 
-        if not res.json().get("event", None):
+        if not res.get("event", None):
             return None
 
-        return res.json()["event"]
+        return res["event"]

--- a/seamapi/events.py
+++ b/seamapi/events.py
@@ -137,7 +137,4 @@ class Events(AbstractEvents):
             params=params,
         )
 
-        if not res.get("event", None):
-            return None
-
-        return res["event"]
+        return res.get("event", None)

--- a/seamapi/locks.py
+++ b/seamapi/locks.py
@@ -83,24 +83,23 @@ class Locks(AbstractLocks):
             A list of locks.
         """
 
-        create_payload = {}
+        list_payload = {}
         if connected_account:
-            create_payload["connected_account_id"] = to_connected_account_id(
+            list_payload["connected_account_id"] = to_connected_account_id(
                 connected_account
             )
         if connect_webview:
-            create_payload["connect_webview_id"] = to_connect_webview_id(
+            list_payload["connect_webview_id"] = to_connect_webview_id(
                 connect_webview
             )
 
-        res = requests.post(
-            f"{self.seam.api_url}/locks/list",
-            json=create_payload,
-            headers={"Authorization": f"Bearer {self.seam.api_key}"},
+        res = self.seam.make_request(
+            "GET",
+            "/locks/list",
+            params=list_payload,
         )
-        if not res.ok:
-            raise Exception(res.text)
-        json_locks = res.json()["devices"]
+        json_locks = res["devices"]
+
         return [Device.from_dict(d) for d in json_locks]
 
     def get(
@@ -127,19 +126,19 @@ class Locks(AbstractLocks):
             A lock dict.
         """
 
-        create_payload = {}
+        get_payload = {}
         if device:
-            create_payload["device_id"] = to_device_id(device)
+            get_payload["device_id"] = to_device_id(device)
         if name:
-            create_payload["name"] = name
-        res = requests.post(
-            f"{self.seam.api_url}/locks/get",
-            headers={"Authorization": f"Bearer {self.seam.api_key}"},
-            json=create_payload,
+            get_payload["name"] = name
+
+        res = self.seam.make_request(
+            "GET",
+            "/locks/get",
+            params=get_payload,
         )
-        if not res.ok:
-            raise Exception(res.text)
-        json_lock = res.json()["device"]
+        json_lock = res["device"]
+
         return Device.from_dict(json_lock)
 
     def lock_door(self, device: Union[DeviceId, Device]) -> ActionAttempt:
@@ -161,15 +160,14 @@ class Locks(AbstractLocks):
         """
 
         device_id = to_device_id(device)
-        res = requests.post(
-            f"{self.seam.api_url}/locks/lock_door",
-            headers={"Authorization": f"Bearer {self.seam.api_key}"},
+        res = self.seam.make_request(
+            "POST",
+            "/locks/lock_door",
             json={"device_id": device_id},
         )
-        if not res.ok:
-            raise Exception(res.text)
+
         return self.seam.action_attempts.poll_until_ready(
-            res.json()["action_attempt"]["action_attempt_id"]
+            res["action_attempt"]["action_attempt_id"]
         )
 
     def unlock_door(self, device: Union[DeviceId, Device]) -> ActionAttempt:
@@ -191,13 +189,12 @@ class Locks(AbstractLocks):
         """
 
         device_id = to_device_id(device)
-        res = requests.post(
-            f"{self.seam.api_url}/locks/unlock_door",
-            headers={"Authorization": f"Bearer {self.seam.api_key}"},
+        res = self.seam.make_request(
+            "POST",
+            "/locks/unlock_door",
             json={"device_id": device_id},
         )
-        if not res.ok:
-            raise Exception(res.text)
+
         return self.seam.action_attempts.poll_until_ready(
-            res.json()["action_attempt"]["action_attempt_id"]
+            res["action_attempt"]["action_attempt_id"]
         )

--- a/seamapi/locks.py
+++ b/seamapi/locks.py
@@ -83,20 +83,20 @@ class Locks(AbstractLocks):
             A list of locks.
         """
 
-        list_payload = {}
+        params = {}
         if connected_account:
-            list_payload["connected_account_id"] = to_connected_account_id(
+            params["connected_account_id"] = to_connected_account_id(
                 connected_account
             )
         if connect_webview:
-            list_payload["connect_webview_id"] = to_connect_webview_id(
+            params["connect_webview_id"] = to_connect_webview_id(
                 connect_webview
             )
 
         res = self.seam.make_request(
             "GET",
             "/locks/list",
-            params=list_payload,
+            params=params,
         )
         json_locks = res["devices"]
 
@@ -126,16 +126,16 @@ class Locks(AbstractLocks):
             A lock dict.
         """
 
-        get_payload = {}
+        params = {}
         if device:
-            get_payload["device_id"] = to_device_id(device)
+            params["device_id"] = to_device_id(device)
         if name:
-            get_payload["name"] = name
+            params["name"] = name
 
         res = self.seam.make_request(
             "GET",
             "/locks/get",
-            params=get_payload,
+            params=params,
         )
         json_lock = res["device"]
 

--- a/seamapi/routes.py
+++ b/seamapi/routes.py
@@ -1,0 +1,23 @@
+from .types import AbstractRoutes
+from .workspaces import Workspaces
+from .devices import Devices
+from .events import Events
+from .connected_accounts import ConnectedAccounts
+from .connect_webviews import ConnectWebviews
+from .locks import Locks
+from .access_codes import AccessCodes
+from .action_attempts import ActionAttempts
+
+class Routes(AbstractRoutes):
+    def __init__(self):
+      self.workspaces = Workspaces(seam=self)
+      self.connected_accounts = ConnectedAccounts(seam=self)
+      self.connect_webviews = ConnectWebviews(seam=self)
+      self.devices = Devices(seam=self)
+      self.events = Events(seam=self)
+      self.locks = Locks(seam=self)
+      self.access_codes = AccessCodes(seam=self)
+      self.action_attempts = ActionAttempts(seam=self)
+
+    def make_request(self):
+      raise NotImplementedError()

--- a/seamapi/seam.py
+++ b/seamapi/seam.py
@@ -88,6 +88,10 @@ class Seam(AbstractSeam):
         parsed_response = response.json()
 
         if response.status_code != 200:
-            raise SeamAPIException(response.status_code, response.headers["seam-request-id"], parsed_response["error"])
+            raise SeamAPIException(
+                response.status_code,
+                response.headers["seam-request-id"],
+                parsed_response["error"],
+            )
 
         return parsed_response

--- a/seamapi/types.py
+++ b/seamapi/types.py
@@ -16,6 +16,13 @@ Email = str
 DeviceType = str  # e.g. august_lock
 WorkspaceId = str
 
+class SeamAPIException(Exception):
+    def __init__(self, status_code: int, request_id: str, metadata: Optional[Dict[str, any]]):
+        self.status_code = status_code
+        self.request_id = request_id
+        self.metadata = metadata
+
+        super().__init__(f"SeamAPIException: status={status_code}, request_id={request_id}, metadata={metadata}")
 
 class ActionAttemptFailedException(Exception):
     def __init__(
@@ -266,18 +273,24 @@ class AbstractConnectedAccounts(abc.ABC):
     ) -> ConnectedAccount:
         raise NotImplementedError
 
-
 @dataclass
-class AbstractSeam(abc.ABC):
-    api_key: str
-    api_url: str
-
+class AbstractRoutes(abc.ABC):
     workspaces: AbstractWorkspaces
     connect_webviews: AbstractConnectWebviews
     locks: AbstractLocks
     devices: AbstractDevices
     access_codes: AbstractAccessCodes
     action_attempts: AbstractActionAttempts
+
+    @abc.abstractmethod
+    def make_request(self, method: str, path: str, **kwargs) -> Any:
+        raise NotImplementedError
+
+
+@dataclass
+class AbstractSeam(AbstractRoutes):
+    api_key: str
+    api_url: str
 
     @abc.abstractmethod
     def __init__(self, api_key: Optional[str] = None):

--- a/seamapi/workspaces.py
+++ b/seamapi/workspaces.py
@@ -118,7 +118,7 @@ class Workspaces(AbstractWorkspaces):
         ------
             ResetSandBoxResponse
         """
-        res = self.seam.make_request(
+        self.seam.make_request(
             "POST",
             "/workspaces/reset_sandbox",
         )

--- a/seamapi/workspaces.py
+++ b/seamapi/workspaces.py
@@ -6,14 +6,13 @@ from seamapi.types import (
     ResetSandBoxResponse,
 )
 from typing import Optional, List, Union
-import requests
 
 from seamapi.utils.convert_to_id import to_workspace_id
 
 
 class Workspaces(AbstractWorkspaces):
     """
-    A class used to retreive workspace data
+    A class used to retrieve workspace data
     through interaction with Seam API
 
     ...
@@ -69,21 +68,15 @@ class Workspaces(AbstractWorkspaces):
         """
 
         workspace_id = None if workspace is None else to_workspace_id(workspace)
-        res = requests.get(
-            f"{self.seam.api_url}/workspaces/list",
+        res = self.seam.make_request(
+            "GET",
+            "/workspaces/list",
             params={"workspace_id": workspace_id},
-            headers={"Authorization": f"Bearer {self.seam.api_key}"},
         )
-        if res.status_code == 404:
-            raise Exception("workspaces not found")  # TODO custom exception
-        if res.status_code != 200:
-            raise Exception(res.text)
-        res_json = res.json()
-        return res_json["workspaces"]
+        return res["workspaces"]
 
     def get(
-        self,
-        workspace: Optional[Union[WorkspaceId, Workspace]] = None,
+        self
     ) -> Workspace:
         """Gets a workspace.
 
@@ -103,21 +96,14 @@ class Workspaces(AbstractWorkspaces):
         ------
             Workspace
         """
-        workspace_id = None if workspace is None else to_workspace_id(workspace)
-        res = requests.get(
-            f"{self.seam.api_url}/workspaces/get",
-            params={"workspace_id": workspace_id},
-            headers={"Authorization": f"Bearer {self.seam.api_key}"},
+        res = self.seam.make_request(
+            "GET",
+            "/workspaces/get",
         )
-        if res.status_code == 404:
-            raise Exception("workspace not found")  # TODO custom exception
-        if res.status_code != 200:
-            raise Exception(res.text)
-        res_json = res.json()
         return Workspace(
-            workspace_id=res_json["workspace"]["workspace_id"],
-            name=res_json["workspace"]["name"],
-            is_sandbox=res_json["workspace"]["is_sandbox"],
+            workspace_id=res["workspace"]["workspace_id"],
+            name=res["workspace"]["name"],
+            is_sandbox=res["workspace"]["is_sandbox"],
         )
 
     def reset_sandbox(self) -> None:
@@ -132,13 +118,10 @@ class Workspaces(AbstractWorkspaces):
         ------
             ResetSandBoxResponse
         """
-
-        res = requests.post(
-            f"{self.seam.api_url}/workspaces/reset_sandbox",
-            headers={"Authorization": f"Bearer {self.seam.api_key}"},
+        res = self.seam.make_request(
+            "POST",
+            "/workspaces/reset_sandbox",
         )
-        if not res.ok:
-            raise Exception(res.text)
 
         return ResetSandBoxResponse(
             message="Successfully reset workspace sandbox",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 from seamapi import Seam
 import time
@@ -29,7 +30,7 @@ def seam_backend():
     with PostgresContainer("postgres:13", dbname="postgres") as pg:
         db_host = "host.docker.internal" if sys.platform == "darwin" else "172.17.0.1"
         db_url = f"postgresql://test:test@{db_host}:{pg.get_exposed_port(pg.port_to_expose)}/postgres"
-        with DockerContainer("ghcr.io/seamapi/seam-connect").with_env(
+        with DockerContainer(os.environ.get("SEAM_CONNECT_IMAGE", "ghcr.io/seamapi/seam-connect")).with_env(
             "DATABASE_URL",
             db_url,
         ).with_env("POSTGRES_DATABASE", "postgres").with_env(

--- a/tests/devices/test_devices.py
+++ b/tests/devices/test_devices.py
@@ -1,4 +1,5 @@
 from seamapi import Seam
+from seamapi.types import SeamAPIException
 from tests.fixtures.run_august_factory import run_august_factory
 from seamapi.utils.deep_attr_dict import DeepAttrDict
 
@@ -34,3 +35,12 @@ def test_devices(seam: Seam):
 
     seam.devices.delete(device=(some_updated_lock))
     assert len(seam.devices.list()) == len(devices) - 1
+
+    # Test custom exception
+    try:
+        seam.devices.get(name="foo")
+        assert False
+    except SeamAPIException as error:
+        assert error.status_code == 404
+        assert type(error.request_id) == str
+        assert error.metadata["type"] == "device_not_found"

--- a/tests/fixtures/run_august_factory.py
+++ b/tests/fixtures/run_august_factory.py
@@ -4,15 +4,13 @@ import requests
 
 
 def run_august_factory(seam: Seam):
-    requests.post(
-        f"{seam.api_url}/internal/scenarios/factories/load",
+    seam.make_request(
+        "POST",
+        "/internal/scenarios/factories/load",
         json={
             "factory_name": "create_august_devices",
             "input": {"num": 1},
             "sync": True,
-        },
-        headers={
-            "Authorization": f"Bearer {seam.api_key}",
         },
     )
 


### PR DESCRIPTION
This will allow us to:

- attach headers to all requests (for example, custom user agents)
- handle exceptions once instead of on a per-request basis

This is a breaking change since thrown exceptions will be slightly different.
