### PR TITLE
feat: Create Access Codes against many devices with same code

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @codetheweb @seveibar @andrii-balitskyi

--- a/seamapi/access_codes.py
+++ b/seamapi/access_codes.py
@@ -187,8 +187,9 @@ class AccessCodes(AbstractAccessCodes):
         starts_at: Optional[str] = None,
         ends_at: Optional[str] = None,
         common_code_key: Optional[str] = None,
-    ) -> AccessCode:
-        """Creates multiple access codes across multiple devices.
+    ) -> List[AccessCode]:
+        """Creates multiple access codes across multiple devices. All access
+        codes will have the same code (if possible).
 
         Parameters
         ----------
@@ -235,12 +236,11 @@ class AccessCodes(AbstractAccessCodes):
             json=create_payload,
         )
 
-        action_attempt = self.seam.action_attempts.poll_until_ready(
-            res["action_attempt"]["action_attempt_id"]
-        )
-        success_res: Any = action_attempt.result
+        access_codes: List[AccessCode] = []
+        for access_code in res["access_codes"]:
+            access_codes.append(AccessCode.from_dict(access_code))
 
-        return AccessCode.from_dict(success_res["access_code"])
+        return access_codes
 
     @report_error
     def update(

--- a/seamapi/access_codes.py
+++ b/seamapi/access_codes.py
@@ -186,7 +186,6 @@ class AccessCodes(AbstractAccessCodes):
         code: Optional[str] = None,
         starts_at: Optional[str] = None,
         ends_at: Optional[str] = None,
-        common_code_key: Optional[str] = None,
     ) -> List[AccessCode]:
         """Creates multiple access codes across multiple devices. All access
         codes will have the same code (if possible).
@@ -227,8 +226,6 @@ class AccessCodes(AbstractAccessCodes):
             create_payload["starts_at"] = starts_at
         if ends_at is not None:
             create_payload["ends_at"] = ends_at
-        if common_code_key is not None:
-            create_payload["common_code_key"] = common_code_key
 
         res = self.seam.make_request(
             "POST",

--- a/seamapi/types.py
+++ b/seamapi/types.py
@@ -16,13 +16,19 @@ Email = str
 DeviceType = str  # e.g. august_lock
 WorkspaceId = str
 
+
 class SeamAPIException(Exception):
-    def __init__(self, status_code: int, request_id: str, metadata: Optional[Dict[str, any]]):
+    def __init__(
+        self, status_code: int, request_id: str, metadata: Optional[Dict[str, any]]
+    ):
         self.status_code = status_code
         self.request_id = request_id
         self.metadata = metadata
 
-        super().__init__(f"SeamAPIException: status={status_code}, request_id={request_id}, metadata={metadata}")
+        super().__init__(
+            f"SeamAPIException: status={status_code}, request_id={request_id}, metadata={metadata}"
+        )
+
 
 class ActionAttemptFailedException(Exception):
     def __init__(
@@ -61,6 +67,7 @@ class Device:
             errors=d["errors"],
         )
 
+
 @dataclass
 class Event:
     event_id: str
@@ -74,6 +81,7 @@ class Event:
     start_time: Union[str, None]
     end_time: Union[str, None]
     created_at: Union[str, None]
+
 
 @dataclass_json
 @dataclass
@@ -189,6 +197,12 @@ class AbstractAccessCodes(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
+    def create_multiple(
+        self, devices: Union[List[DeviceId], List[Device]], name: str, code: str
+    ) -> AccessCode:
+        raise NotImplementedError
+
+    @abc.abstractmethod
     def create(
         self, device: Union[DeviceId, Device], name: str, code: str
     ) -> AccessCode:
@@ -228,10 +242,12 @@ class AbstractDevices(abc.ABC):
     ) -> Device:
         raise NotImplementedError
 
+
 class AbstractEvents(abc.ABC):
     @abc.abstractmethod
     def list(self) -> List[Event]:
         raise NotImplementedError
+
 
 class AbstractWorkspaces(abc.ABC):
     @abc.abstractmethod
@@ -274,6 +290,7 @@ class AbstractConnectedAccounts(abc.ABC):
     ) -> ConnectedAccount:
         raise NotImplementedError
 
+
 @dataclass
 class AbstractRoutes(abc.ABC):
     workspaces: AbstractWorkspaces
@@ -296,6 +313,7 @@ class AbstractSeam(AbstractRoutes):
     @abc.abstractmethod
     def __init__(self, api_key: Optional[str] = None):
         raise NotImplementedError
+
 
 @dataclass_json
 @dataclass

--- a/seamapi/types.py
+++ b/seamapi/types.py
@@ -148,6 +148,7 @@ class AccessCode:
     ends_at: Optional[str] = None
     name: Optional[str] = ""
     status: Optional[str] = None
+    common_code_key: Optional[str] = None
 
 
 class AbstractActionAttempts(abc.ABC):
@@ -198,13 +199,25 @@ class AbstractAccessCodes(abc.ABC):
 
     @abc.abstractmethod
     def create_multiple(
-        self, devices: Union[List[DeviceId], List[Device]], name: str, code: str
-    ) -> AccessCode:
+        self,
+        devices: Union[List[DeviceId], List[Device]],
+        name: Optional[str] = None,
+        code: Optional[str] = None,
+        starts_at: Optional[str] = None,
+        ends_at: Optional[str] = None,
+        common_code_key: Optional[str] = None,
+    ) -> List[AccessCode]:
         raise NotImplementedError
 
     @abc.abstractmethod
     def create(
-        self, device: Union[DeviceId, Device], name: str, code: str
+        self,
+        device: Union[DeviceId, Device],
+        name: Optional[str] = None,
+        code: Optional[str] = None,
+        starts_at: Optional[str] = None,
+        ends_at: Optional[str] = None,
+        common_code_key: Optional[str] = None,
     ) -> AccessCode:
         raise NotImplementedError
 

--- a/tests/access_codes/test_access_codes.py
+++ b/tests/access_codes/test_access_codes.py
@@ -31,5 +31,7 @@ def test_access_codes(seam: Seam):
     delete_action_attempt = seam.access_codes.delete(created_access_code)
     assert delete_action_attempt.status == "success"
 
-    access_code_2 = seam.access_codes.create_multiple(devices=all_devices)
-    assert access_code_2.common_code_key == "helloworld"
+    access_codes = seam.access_codes.create_multiple(devices=all_devices)
+    print(access_codes)
+    assert len(access_codes) == len(all_devices)
+    assert len(set([ac.common_code_key for ac in access_codes])) == 1

--- a/tests/access_codes/test_access_codes.py
+++ b/tests/access_codes/test_access_codes.py
@@ -32,6 +32,5 @@ def test_access_codes(seam: Seam):
     assert delete_action_attempt.status == "success"
 
     access_codes = seam.access_codes.create_multiple(devices=all_devices)
-    print(access_codes)
     assert len(access_codes) == len(all_devices)
     assert len(set([ac.common_code_key for ac in access_codes])) == 1

--- a/tests/access_codes/test_access_codes.py
+++ b/tests/access_codes/test_access_codes.py
@@ -7,7 +7,8 @@ import pytest
 def test_access_codes(seam: Seam):
     run_august_factory(seam)
 
-    some_device = seam.devices.list()[0]
+    all_devices = seam.devices.list()
+    some_device = all_devices[0]
 
     created_access_code = seam.access_codes.create(
         some_device.device_id, "Test code", "4444"
@@ -29,3 +30,6 @@ def test_access_codes(seam: Seam):
 
     delete_action_attempt = seam.access_codes.delete(created_access_code)
     assert delete_action_attempt.status == "success"
+
+    access_code_2 = seam.access_codes.create_multiple(devices=all_devices)
+    assert access_code_2.common_code_key == "helloworld"


### PR DESCRIPTION
## Usage

```python
all_devices = seam.devices.list()

access_codes = seam.access_codes.create_multiple(devices=all_devices)
# all access codes will have the same code, this works with time bound codes too!

```

```python
# We also now support having the same code on multiple locks using `common_code_key`
access_codes.create(device=device_id, common_code_key="mycode1")
access_codes.create(device=device_id, common_code_key="mycode2")

# These access codes will have the same code, also works with time bound codes!
```