### PR TITLE
test: Add access_codes.create_multiple test

### DIFF
--- a/tests/access_codes/test_access_codes.py
+++ b/tests/access_codes/test_access_codes.py
@@ -53,6 +53,11 @@ def test_access_codes_create_wait_for_code(seam: Seam):
 
     with pytest.raises(RuntimeError) as excinfo:
         seam.access_codes.create(
-            some_device.device_id, "Test code", "4445", wait_for_code=True, starts_at="3001-01-01", ends_at="3001-01-03"
+            some_device.device_id,
+            "Test code",
+            "4445",
+            wait_for_code=True,
+            starts_at="3001-01-01",
+            ends_at="3001-01-03",
         )
     assert "future time bound code" in str(excinfo.value)

--- a/tests/access_codes/test_access_codes.py
+++ b/tests/access_codes/test_access_codes.py
@@ -33,10 +33,10 @@ def test_access_codes(seam: Seam):
     delete_action_attempt = seam.access_codes.delete(created_access_code)
     assert delete_action_attempt.status == "success"
 
-    multiple_devices = [d for d in all_devices if d.device_type == "salto_lock" ]
-    access_codes = seam.access_codes.create_multiple(devices=multiple_devices)
-    assert len(access_codes) == len(multiple_devices)
+    access_codes = seam.access_codes.create_multiple(devices=all_devices)
+    assert len(access_codes) == len(all_devices)
     assert len(set([ac.common_code_key for ac in access_codes])) == 1
+
 
 def test_access_codes_create_wait_for_code(seam: Seam):
     run_august_factory(seam)

--- a/tests/access_codes/test_access_codes.py
+++ b/tests/access_codes/test_access_codes.py
@@ -1,11 +1,13 @@
 from seamapi import Seam
 from seamapi.types import SeamAPIException
 from tests.fixtures.run_august_factory import run_august_factory
+from tests.fixtures.run_salto_factory import run_salto_factory
 import pytest
 
 
 def test_access_codes(seam: Seam):
     run_august_factory(seam)
+    run_salto_factory(seam)
 
     all_devices = seam.devices.list()
     some_device = all_devices[0]
@@ -31,10 +33,10 @@ def test_access_codes(seam: Seam):
     delete_action_attempt = seam.access_codes.delete(created_access_code)
     assert delete_action_attempt.status == "success"
 
-    # TODO: Can only test for salto devices.
-    # access_codes = seam.access_codes.create_multiple(devices=all_devices)
-    # assert len(access_codes) == len(all_devices)
-    # assert len(set([ac.common_code_key for ac in access_codes])) == 1
+    multiple_devices = [d for d in all_devices if d.device_type == "salto_lock" ]
+    access_codes = seam.access_codes.create_multiple(devices=multiple_devices)
+    assert len(access_codes) == len(multiple_devices)
+    assert len(set([ac.common_code_key for ac in access_codes])) == 1
 
 def test_access_codes_create_wait_for_code(seam: Seam):
     run_august_factory(seam)

--- a/tests/fixtures/run_august_factory.py
+++ b/tests/fixtures/run_august_factory.py
@@ -13,6 +13,3 @@ def run_august_factory(seam: Seam):
             "sync": True,
         },
     )
-
-    # TODO remove when sync is supported in /internal/scenarios/factories/load
-    time.sleep(0.2)

--- a/tests/fixtures/run_salto_factory.py
+++ b/tests/fixtures/run_salto_factory.py
@@ -9,7 +9,7 @@ def run_salto_factory(seam: Seam):
         "/internal/scenarios/factories/load",
         json={
             "factory_name": "create_salto_devices",
-            "input": {"num": 1},
+            "input": {"num": 3},
             "sync": True,
         },
     )

--- a/tests/fixtures/run_salto_factory.py
+++ b/tests/fixtures/run_salto_factory.py
@@ -1,0 +1,15 @@
+from seamapi import Seam
+import time
+import requests
+
+
+def run_salto_factory(seam: Seam):
+    seam.make_request(
+        "POST",
+        "/internal/scenarios/factories/load",
+        json={
+            "factory_name": "create_salto_devices",
+            "input": {"num": 1},
+            "sync": True,
+        },
+    )


### PR DESCRIPTION
Seam connect now supports common code key on multiple lock types.