### PR TITLE
Use pg.get_container_host_ip and pg.get_connection_url

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,8 @@ jobs:
             ⌛️ [running Python SDK tests](${{ env.RUN_URL }})...
       - run: poetry install
       - run: poetry run pytest -s
+        env:
+          TC_HOST: 172.17.0.1
       - name: Comment on failure
         if: ${{ github.event.inputs.prNumber && failure() }}
         uses: marocchino/sticky-pull-request-comment@v2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,7 +32,8 @@ def seam_backend():
         db_url = pg.get_connection_url()
 
         # UPSTREAM: https://github.com/testcontainers/testcontainers-python/issues/159
-        if os.environ.get("CI") is not None:
+        docker_info = pg.get_docker_client().client.info()
+        if docker_info["OperatingSystem"] == "docker-desktop":
             container_host = "host.docker.internal"
             db_url = db_url.replace(db_host, container_host)
             db_host = container_host

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,9 @@ class SeamBackend:
 @pytest.fixture(scope="function")
 def seam_backend():
     with PostgresContainer("postgres:13", dbname="postgres") as pg:
+        db_host = pg.get_container_host_ip()
+        db_url = pg.get_connection_url()
+
         # UPSTREAM: https://github.com/testcontainers/testcontainers-python/issues/159
         if os.environ.get("CI"):
             container_host = "host.docker.internal"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,8 @@ def seam_backend():
 
         # UPSTREAM: https://github.com/testcontainers/testcontainers-python/issues/159
         docker_info = pg.get_docker_client().client.info()
-        if docker_info["OperatingSystem"] == "docker-desktop":
+        print(docker_info["OperatingSystem"])
+        if docker_info["OperatingSystem"] == "Docker Desktop":
             container_host = "host.docker.internal"
             db_url = db_url.replace(db_host, container_host)
             db_host = container_host

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,7 +32,7 @@ def seam_backend():
         db_url = pg.get_connection_url()
 
         # UPSTREAM: https://github.com/testcontainers/testcontainers-python/issues/159
-        if os.environ.get("CI"):
+        if os.environ.get("CI") is not None:
             container_host = "host.docker.internal"
             db_url = db_url.replace(db_host, container_host)
             db_host = container_host

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,22 +28,18 @@ class SeamBackend:
 @pytest.fixture(scope="function")
 def seam_backend():
     with PostgresContainer("postgres:13", dbname="postgres") as pg:
-        db_host = (
-            "host.docker.internal"
-            if sys.platform == "darwin"
-            else "172.17.0.1"
-        )
-        db_url = f"postgresql://test:test@{db_host}:{pg.get_exposed_port(pg.port_to_expose)}/postgres"
         with DockerContainer(
             os.environ.get(
                 "SEAM_CONNECT_IMAGE", "ghcr.io/seamapi/seam-connect"
             )
-        ).with_env("DATABASE_URL", db_url,).with_env(
+        ).with_env(
+            "DATABASE_URL", pg.get_connection_url()
+        ).with_env(
             "POSTGRES_DATABASE", "postgres"
         ).with_env(
             "NODE_ENV", "test"
         ).with_env(
-            "POSTGRES_HOST", db_host
+            "POSTGRES_HOST", pg.get_container_host_ip()
         ).with_env(
             "SERVER_BASE_URL", "http://localhost:3020"
         ).with_env(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,18 @@ class SeamBackend:
 @pytest.fixture(scope="function")
 def seam_backend():
     with PostgresContainer("postgres:13", dbname="postgres") as pg:
+        db_host = (
+            "host.docker.internal"
+            if sys.platform == "darwin"
+            else "172.17.0.1"
+        )
+        print(db_host)
+        print(pg.get_container_host_ip())
+
+        db_url = f"postgresql://test:test@{db_host}:{pg.get_exposed_port(pg.port_to_expose)}/postgres"
+        print(db_url)
+        print(pg.get_connection_url())
+
         with DockerContainer(
             os.environ.get(
                 "SEAM_CONNECT_IMAGE", "ghcr.io/seamapi/seam-connect"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,6 @@ def seam_backend():
 
         # UPSTREAM: https://github.com/testcontainers/testcontainers-python/issues/159
         docker_info = pg.get_docker_client().client.info()
-        print(docker_info["OperatingSystem"])
         if docker_info["OperatingSystem"] == "Docker Desktop":
             container_host = "host.docker.internal"
             db_url = db_url.replace(db_host, container_host)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,30 +28,24 @@ class SeamBackend:
 @pytest.fixture(scope="function")
 def seam_backend():
     with PostgresContainer("postgres:13", dbname="postgres") as pg:
-        db_host = (
-            "host.docker.internal"
-            if sys.platform == "darwin"
-            else "172.17.0.1"
-        )
-        print(db_host)
-        print(pg.get_container_host_ip())
-
-        db_url = f"postgresql://test:test@{db_host}:{pg.get_exposed_port(pg.port_to_expose)}/postgres"
-        print(db_url)
-        print(pg.get_connection_url())
+        # UPSTREAM: https://github.com/testcontainers/testcontainers-python/issues/159
+        if os.environ.get("CI"):
+            container_host = "host.docker.internal"
+            db_url = db_url.replace(db_host, container_host)
+            db_host = container_host
 
         with DockerContainer(
             os.environ.get(
                 "SEAM_CONNECT_IMAGE", "ghcr.io/seamapi/seam-connect"
             )
         ).with_env(
-            "DATABASE_URL", pg.get_connection_url()
+            "DATABASE_URL", db_url
         ).with_env(
             "POSTGRES_DATABASE", "postgres"
         ).with_env(
             "NODE_ENV", "test"
         ).with_env(
-            "POSTGRES_HOST", pg.get_container_host_ip()
+            "POSTGRES_HOST", db_host,
         ).with_env(
             "SERVER_BASE_URL", "http://localhost:3020"
         ).with_env(


### PR DESCRIPTION
- `get_container_host_ip()` and `get_connection_url()` are provided by test containers as the way to get the correct URL to use, so they are preferred first.
- `TC_HOST` is provided as an override for environments where testcontainers does not resolve the correct host address, in this case GitHub actions (removes hard-coded fallback that does not work on all platforms).
- The `Docker Desktop` check is a workaround for this issue https://github.com/testcontainers/testcontainers-python/issues/159 which affects any platform using docker desktop, not just darwin.

Note there is a completely separate issue (I will add to README in other PR) of finding the correct docker socket when using docker desktop. Docker [patched this back for mac](https://docs.docker.com/desktop/release-notes/), but did not do the same for linux, so linux users must use a workaround like https://github.com/testcontainers/testcontainers-node/issues/407#issuecomment-1289311726 or https://github.com/testcontainers/testcontainers-node/issues/407#issuecomment-1290268401

<img width="806" alt="image" src="https://user-images.githubusercontent.com/721372/205194780-e2535a67-5f14-4e97-beba-daba9cea1ea8.png">
