### PR TITLE
ci: Start docker in postAttachCommand

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,6 +21,7 @@
     "EditorConfig.EditorConfig"
   ],
   "runArgs": ["--volume=/var/lib/docker", "--privileged"],
-  "postCreateCommand": "sudo service docker start && poetry install",
+  "postCreateCommand": "poetry install",
+  "postAttachCommand": "sudo service docker start",
   "remoteUser": "vscode"
 }


### PR DESCRIPTION
Needs to be on each attach since the service will be stopped when the codespace is paused.