### PR TITLE
Add `devices.unmanaged.get` method, add `is_managed` and `capabilities_supported` props to unmanaged device object

### DIFF
--- a/seamapi/devices.py
+++ b/seamapi/devices.py
@@ -288,6 +288,8 @@ class UnmanagedDevices(AbstractUnmanagedDevices):
 
     Methods
     -------
+    get(device=None, name=None)
+        Gets an unmanaged device
     list(connected_account=None, connected_accounts=None, connect_webview=None, device_type=None, device_ids=None, manufacturer=None)
         Gets a list of unmanaged devices
     update(device, is_managed)
@@ -305,6 +307,47 @@ class UnmanagedDevices(AbstractUnmanagedDevices):
         """
 
         self.seam = seam
+
+    @report_error
+    def get(
+        self,
+        device: Optional[Union[DeviceId, Device]] = None,
+        name: Optional[str] = None,
+    ) -> UnmanagedDevice:
+        """Gets an unmanaged devices.
+
+        Parameters
+        ----------
+        device : Union[DeviceId, Device], optional
+            Device ID or Device
+        name : str, optional
+            Device name
+
+        Raises
+        ------
+        Exception
+            If the API request wasn't successful.
+
+        Returns
+        ------
+            An unmanaged device.
+        """
+
+        params = {}
+
+        if device:
+            params["device_id"] = to_device_id(device)
+        if name:
+            params["name"] = name
+
+        res = self.seam.make_request(
+            "GET",
+            "/devices/unmanaged/get",
+            params=params,
+        )
+        json_device = res["device"]
+
+        return UnmanagedDevice.from_dict(json_device)
 
     @report_error
     def list(

--- a/seamapi/types.py
+++ b/seamapi/types.py
@@ -73,7 +73,6 @@ class Device:
     connected_account_id: str
     workspace_id: str
     created_at: str
-    capabilities_supported: List[str]
     is_managed: bool
 
     @staticmethod
@@ -89,7 +88,6 @@ class Device:
             connected_account_id=d["connected_account_id"],
             workspace_id=d["workspace_id"],
             created_at=d["created_at"],
-            capabilities_supported=d["capabilities_supported"],
             is_managed=d["is_managed"],
         )
 

--- a/seamapi/types.py
+++ b/seamapi/types.py
@@ -73,6 +73,8 @@ class Device:
     connected_account_id: str
     workspace_id: str
     created_at: str
+    capabilities_supported: List[str]
+    is_managed: bool
 
     @staticmethod
     def from_dict(d: Dict[str, Any]):
@@ -87,6 +89,8 @@ class Device:
             connected_account_id=d["connected_account_id"],
             workspace_id=d["workspace_id"],
             created_at=d["created_at"],
+            capabilities_supported=d["capabilities_supported"],
+            is_managed=d["is_managed"],
         )
 
 
@@ -100,6 +104,8 @@ class UnmanagedDevice:
     created_at: str
     errors: List[Dict[str, Any]]
     warnings: List[Dict[str, Any]]
+    capabilities_supported: List[str]
+    is_managed: bool
 
     @staticmethod
     def from_dict(d: Dict[str, Any]):
@@ -112,6 +118,8 @@ class UnmanagedDevice:
             created_at=d["created_at"],
             errors=d["errors"],
             warnings=d["warnings"],
+            capabilities_supported=d["capabilities_supported"],
+            is_managed=d["is_managed"],
         )
 
 
@@ -407,6 +415,14 @@ class AbstractNoiseSensors(abc.ABC):
 
 
 class AbstractUnmanagedDevices(abc.ABC):
+    @abc.abstractmethod
+    def get(
+        self,
+        device: Optional[Union[DeviceId, Device]] = None,
+        name: Optional[str] = None,
+    ) -> UnmanagedDevice:
+        raise NotImplementedError
+
     @abc.abstractmethod
     def list(
         self,

--- a/tests/devices/test_devices.py
+++ b/tests/devices/test_devices.py
@@ -85,6 +85,11 @@ def test_unmanaged_devices(seam: Seam):
     unmanaged_devices = seam.devices.unmanaged.list()
     assert len(unmanaged_devices) == 1
 
+    unmanaged_device = seam.devices.unmanaged.get(device=device)
+    assert unmanaged_device.device_id == device.device_id
+    unmanaged_device = seam.devices.unmanaged.get(name=device.properties.name)
+    assert unmanaged_device.properties.name == device.properties.name
+
     connected_account = seam.connected_accounts.list()[0]
     devices = seam.devices.unmanaged.list(connected_account=connected_account)
     assert len(devices) > 0


### PR DESCRIPTION
In relation to https://github.com/seamapi/python/issues/112
