### PR TITLE
Add `appearance` and `allow_external_modification` to access code API + add unmanaged access code API

### DIFF
--- a/seamapi/access_codes.py
+++ b/seamapi/access_codes.py
@@ -608,7 +608,7 @@ class UnmanagedAccessCodes(AbstractUnmanagedAccessCodes):
         Parameters
         ----------
         access_code : AccessCodeId or UnmanagedAccessCode
-            Access Code ID or UnmanagedAccessCode update
+            Access Code ID or UnmanagedAccessCode
         allow_external_modification : bool
             Allow external modifications of the access code e.g. through the lock provider's app. False by default.
 

--- a/seamapi/access_codes.py
+++ b/seamapi/access_codes.py
@@ -523,18 +523,18 @@ class UnmanagedAccessCodes(AbstractUnmanagedAccessCodes):
     @report_error
     def get(
         self,
-        device: Optional[Union[DeviceId, Device]] = None,
         access_code: Optional[Union[AccessCodeId, AccessCode]] = None,
+        device: Optional[Union[DeviceId, Device]] = None,
         code: Optional[str] = None,
     ) -> UnmanagedAccessCode:
         """Gets an unmanaged access code.
 
         Parameters
         ----------
-        device : Union[DeviceId, Device], optional
-            Device ID or Device
         access_code : Union[AccessCodeId, UnmanagedAccessCode], optional
             Access Code ID or Access Code
+        device : Union[DeviceId, Device], optional
+            Device ID or Device
         code : str, optional
             Pin code of an access code
 
@@ -553,7 +553,7 @@ class UnmanagedAccessCodes(AbstractUnmanagedAccessCodes):
         if device:
             params["device_id"] = to_device_id(device)
         if access_code:
-            params["access_code_id"] = to_access_code_id(device)
+            params["access_code_id"] = to_access_code_id(access_code)
         if code:
             params["code"] = code
 

--- a/seamapi/types.py
+++ b/seamapi/types.py
@@ -198,6 +198,8 @@ class AccessCode:
     type: str
     code: str
     created_at: str
+    errors: List[Dict[str, Any]]
+    warnings: List[Dict[str, Any]]
     starts_at: Optional[str] = None
     ends_at: Optional[str] = None
     name: Optional[str] = ""
@@ -209,6 +211,25 @@ class AccessCode:
     pulled_backup_access_code_id: Optional[str] = None
     is_backup_access_code_available: Optional[bool] = None
     is_backup: Optional[bool] = None
+    appearance: Optional[Dict[str, Any]] = None
+    allow_external_modification: Optional[bool] = None
+
+
+@dataclass_json
+@dataclass
+class UnmanagedAccessCode:
+    access_code_id: str
+    device_id: str
+    type: str
+    name: Optional[str] = ""
+    created_at: str
+    errors: List[Dict[str, Any]]
+    warnings: List[Dict[str, Any]]
+    code: Optional[str] = None
+    is_managed: Optional[bool] = None
+    starts_at: Optional[str] = None
+    ends_at: Optional[str] = None
+    status: Optional[str] = None
 
 
 @dataclass
@@ -379,6 +400,32 @@ class AbstractAccessCodes(abc.ABC):
         self,
         access_code: Union[AccessCode, AccessCodeId],
     ) -> AccessCode:
+        raise NotImplementedError
+
+
+class AbstractUnmanagedAccessCodes(abc.ABC):
+    @abc.abstractmethod
+    def get(
+        self,
+        device: Optional[Union[DeviceId, Device]] = None,
+        access_code: Optional[Union[AccessCodeId, UnmanagedAccessCode]] = None,
+        code: Optional[str] = None,
+    ) -> UnmanagedAccessCode:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def list(
+        self,
+        device: Union[DeviceId, Device],
+    ) -> List[UnmanagedAccessCode]:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def convert_to_managed(
+        self,
+        access_code: Union[AccessCodeId, UnmanagedAccessCode],
+        allow_external_modification: Optional[bool] = None,
+    ) -> ActionAttempt:
         raise NotImplementedError
 
 

--- a/seamapi/types.py
+++ b/seamapi/types.py
@@ -222,9 +222,9 @@ class UnmanagedAccessCode:
     device_id: str
     type: str
     created_at: str
-    name: Optional[str] = ""
     errors: List[Dict[str, Any]]
     warnings: List[Dict[str, Any]]
+    name: Optional[str] = ""
     code: Optional[str] = None
     is_managed: Optional[bool] = None
     starts_at: Optional[str] = None

--- a/seamapi/types.py
+++ b/seamapi/types.py
@@ -328,7 +328,35 @@ class AbstractLocks(abc.ABC):
         raise NotImplementedError
 
 
+class AbstractUnmanagedAccessCodes(abc.ABC):
+    @abc.abstractmethod
+    def get(
+        self,
+        device: Optional[Union[DeviceId, Device]] = None,
+        access_code: Optional[Union[AccessCodeId, UnmanagedAccessCode]] = None,
+        code: Optional[str] = None,
+    ) -> UnmanagedAccessCode:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def list(
+        self,
+        device: Union[DeviceId, Device],
+    ) -> List[UnmanagedAccessCode]:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def convert_to_managed(
+        self,
+        access_code: Union[AccessCodeId, UnmanagedAccessCode],
+        allow_external_modification: Optional[bool] = None,
+    ) -> ActionAttempt:
+        raise NotImplementedError
+
+
 class AbstractAccessCodes(abc.ABC):
+    unmanaged: AbstractUnmanagedAccessCodes
+
     @abc.abstractmethod
     def list(
         self,
@@ -400,32 +428,6 @@ class AbstractAccessCodes(abc.ABC):
         self,
         access_code: Union[AccessCode, AccessCodeId],
     ) -> AccessCode:
-        raise NotImplementedError
-
-
-class AbstractUnmanagedAccessCodes(abc.ABC):
-    @abc.abstractmethod
-    def get(
-        self,
-        device: Optional[Union[DeviceId, Device]] = None,
-        access_code: Optional[Union[AccessCodeId, UnmanagedAccessCode]] = None,
-        code: Optional[str] = None,
-    ) -> UnmanagedAccessCode:
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def list(
-        self,
-        device: Union[DeviceId, Device],
-    ) -> List[UnmanagedAccessCode]:
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def convert_to_managed(
-        self,
-        access_code: Union[AccessCodeId, UnmanagedAccessCode],
-        allow_external_modification: Optional[bool] = None,
-    ) -> ActionAttempt:
         raise NotImplementedError
 
 

--- a/seamapi/types.py
+++ b/seamapi/types.py
@@ -221,8 +221,8 @@ class UnmanagedAccessCode:
     access_code_id: str
     device_id: str
     type: str
-    name: Optional[str] = ""
     created_at: str
+    name: Optional[str] = ""
     errors: List[Dict[str, Any]]
     warnings: List[Dict[str, Any]]
     code: Optional[str] = None

--- a/tests/access_codes/test_access_codes.py
+++ b/tests/access_codes/test_access_codes.py
@@ -76,18 +76,3 @@ def test_access_codes_create_wait_for_code(seam: Seam):
             ends_at="3001-01-03",
         )
     assert "future time bound code" in str(excinfo.value)
-
-def test_unmanaged_access_codes(seam: Seam):
-    run_august_factory(seam)
-
-    device = seam.devices.list()[0]
-
-    access_code = seam.access_codes.create(
-        device, "Test code", "8989"
-    )
-    unmanaged_access_codes = seam.access_codes.unmanaged.list(device)
-    assert len(unmanaged_access_codes) == 0
-
-    seam.access_codes.unmanaged.get(access_code)
-
-    

--- a/tests/access_codes/test_access_codes.py
+++ b/tests/access_codes/test_access_codes.py
@@ -76,3 +76,18 @@ def test_access_codes_create_wait_for_code(seam: Seam):
             ends_at="3001-01-03",
         )
     assert "future time bound code" in str(excinfo.value)
+
+def test_unmanaged_access_codes(seam: Seam):
+    run_august_factory(seam)
+
+    device = seam.devices.list()[0]
+
+    access_code = seam.access_codes.create(
+        device, "Test code", "8989"
+    )
+    unmanaged_access_codes = seam.access_codes.unmanaged.list(device)
+    assert len(unmanaged_access_codes) == 0
+
+    seam.access_codes.unmanaged.get(access_code)
+
+    


### PR DESCRIPTION
In relation to https://github.com/seamapi/python/issues/112