### PR TITLE
fix: Handle non-json response

### DIFF
--- a/seamapi/__init__.py
+++ b/seamapi/__init__.py
@@ -2,3 +2,4 @@
 # type: ignore
 
 from seamapi.seam import Seam
+from seamapi.seam import SeamAPIException

--- a/seamapi/seam.py
+++ b/seamapi/seam.py
@@ -124,13 +124,10 @@ class Seam(AbstractSeam):
             )
 
 
-        parsed_response = response.json()
-
         if response.status_code != 200:
-            raise SeamAPIException(
-                response.status_code,
-                response.headers["seam-request-id"],
-                parsed_response["error"],
-            )
+            raise SeamAPIException(response)
 
-        return parsed_response
+        if "application/json" in response.headers["content-type"]:
+            return response.json()
+
+        return response.text

--- a/seamapi/types.py
+++ b/seamapi/types.py
@@ -22,16 +22,18 @@ ClimateSettingScheduleId = str
 class SeamAPIException(Exception):
     def __init__(
         self,
-        status_code: int,
-        request_id: str,
-        metadata: Optional[Dict[str, any]],
+        response,
     ):
-        self.status_code = status_code
-        self.request_id = request_id
-        self.metadata = metadata
+        self.status_code = response.status_code
+        self.request_id = response.headers.get("seam-request-id", None)
+
+        self.metadata = None
+        if "application/json" in response.headers["content-type"]:
+            parsed_response = response.json()
+            self.metadata = parsed_response["error"]
 
         super().__init__(
-            f"SeamAPIException: status={status_code}, request_id={request_id}, metadata={metadata}"
+            f"SeamAPIException: status={self.status_code}, request_id={self.request_id}, metadata={self.metadata}"
         )
 
 

--- a/seamapi/types.py
+++ b/seamapi/types.py
@@ -30,7 +30,7 @@ class SeamAPIException(Exception):
         self.metadata = None
         if "application/json" in response.headers["content-type"]:
             parsed_response = response.json()
-            self.metadata = parsed_response["error"]
+            self.metadata = parsed_response.get("error", None)
 
         super().__init__(
             f"SeamAPIException: status={self.status_code}, request_id={self.request_id}, metadata={self.metadata}"


### PR DESCRIPTION
Only try to parse response as JSON if the content type is JSON.